### PR TITLE
Add Civil IoT water level map demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# Water
+# Water Level Map Demo
+
+This demo fetches nearby water level sensors from Taiwan's Civil IoT (SensorThings API) and visualizes them on a Leaflet map. Users can click the button to locate themselves and display the latest water level readings from sensors within a 5 km radius.
+
+The data is retrieved from the Civil IoT FROST server. Update `API_BASE` in `public/script.js` if the endpoint changes.
+
+## Usage
+
+Open `public/index.html` in a browser. The page requires internet access to load map tiles and query the Civil IoT API.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <title>附近水位感測器地圖</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>附近水位感測器地圖</h1>
+  <button id="locate-btn">定位並顯示水位</button>
+  <div id="map" style="height: 500px;"></div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,56 @@
+const API_BASE = 'https://iot.kiang.org.tw/civil-iot/v1.0'; // Replace with actual API base
+
+const map = L.map('map').setView([23.6978, 120.9605], 7); // Taiwan center
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+document.getElementById('locate-btn').addEventListener('click', () => {
+  if (!navigator.geolocation) {
+    alert('瀏覽器不支援地理定位');
+    return;
+  }
+
+  navigator.geolocation.getCurrentPosition(pos => {
+    const { latitude, longitude } = pos.coords;
+    map.setView([latitude, longitude], 13);
+    L.marker([latitude, longitude]).addTo(map).bindPopup('您所在的位置').openPopup();
+    fetchNearbySensors(latitude, longitude);
+  }, err => {
+    alert('取得定位失敗: ' + err.message);
+  });
+});
+
+function fetchNearbySensors(lat, lon) {
+  const radius = 5000; // 5 km
+  const url = `${API_BASE}/Things?$filter=st_distance(Locations/location, geography'POINT(${lon} ${lat})')%20lt%20${radius}&$expand=Datastreams($top=1;$orderby=phenomenonTime%20desc),Locations`;
+  fetch(url)
+    .then(res => res.json())
+    .then(data => {
+      (data.value || []).forEach(thing => {
+        const loc = thing.Locations[0];
+        if (!loc) return;
+        const coords = loc.location.coordinates.reverse(); // [lat, lon]
+        const datastream = thing.Datastreams[0];
+        if (!datastream) return;
+
+        fetchLatestObservation(datastream['@iot.id']).then(result => {
+          const value = result ? result.result : '無資料';
+          const popup = `${thing.name}<br>水位: ${value}`;
+          L.marker(coords).addTo(map).bindPopup(popup);
+        });
+      });
+    })
+    .catch(err => {
+      console.error(err);
+      alert('取得感測器資料失敗');
+    });
+}
+
+function fetchLatestObservation(datastreamId) {
+  const url = `${API_BASE}/Datastreams(${datastreamId})/Observations?$top=1&$orderby=phenomenonTime%20desc`;
+  return fetch(url)
+    .then(res => res.json())
+    .then(data => data.value && data.value[0])
+    .catch(() => null);
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,9 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+#map {
+  width: 100%;
+  height: 500px;
+}


### PR DESCRIPTION
## Summary
- build a web demo showing nearby water level sensors
- Leaflet map locates user and fetches SensorThings API data
- document how to run the page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887a38641b0832da5182b596b3eafe2