### PR TITLE
Add root index for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The data is retrieved from the Civil IoT FROST server. Update `API_BASE` in `pub
 
 ## Usage
 
-Open `public/index.html` in a browser. The page requires internet access to load map tiles and query the Civil IoT API.
+Open `index.html` or `public/index.html` in a browser. The page requires internet access to load map tiles and query the Civil IoT API.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <title>附近水位感測器地圖</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <link rel="stylesheet" href="public/style.css" />
+</head>
+<body>
+  <h1>附近水位感測器地圖</h1>
+  <button id="locate-btn">定位並顯示水位</button>
+  <div id="map" style="height: 500px;"></div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="public/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an `index.html` at repo root referencing assets in `public`
- update usage instructions in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887a8cc5678832d94dce54321999486