### PR TITLE
Add prototype graph API and visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,16 @@ The data is retrieved from the Civil IoT FROST server. Update `API_BASE` in `pub
 ## Usage
 
 Open `index.html` or `public/index.html` in a browser. The page requires internet access to load map tiles and query the Civil IoT API.
+
+## Prototype Graph API
+
+A minimal prototype graph server and visualization is included as a starting point for a DataWalk-style system. Run the server and open the graph demo:
+
+```bash
+node server.js
+```
+
+Then browse to `http://localhost:4000/graph.html` to see the sample graph rendered with Cytoscape.js. The server exposes:
+
+- **REST**: `GET /api/graph` returns all nodes and edges.
+- **GraphQL**: `POST /graphql` accepts simple queries like `{ nodes { id label } }` or `{ node(id: "1") { id label } }`.

--- a/data/graph.json
+++ b/data/graph.json
@@ -1,0 +1,12 @@
+{
+  "nodes": [
+    {"id": "1", "label": "Alice", "type": "Person"},
+    {"id": "2", "label": "Bob", "type": "Person"},
+    {"id": "3", "label": "ACME Corp", "type": "Organization"}
+  ],
+  "edges": [
+    {"id": "e1", "source": "1", "target": "3", "label": "works_at"},
+    {"id": "e2", "source": "2", "target": "3", "label": "works_at"},
+    {"id": "e3", "source": "1", "target": "2", "label": "knows"}
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "water",
+  "version": "1.0.0",
+  "description": "Water Level map and prototype graph server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node server.js & sleep 1 && kill $!"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/graph.html
+++ b/public/graph.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Graph Prototype</title>
+  <script src="https://unpkg.com/cytoscape@3.24.0/dist/cytoscape.min.js"></script>
+  <script defer src="graph.js"></script>
+  <style>
+    #cy { width: 100%; height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="cy"></div>
+</body>
+</html>

--- a/public/graph.js
+++ b/public/graph.js
@@ -1,0 +1,22 @@
+async function loadGraph() {
+  const res = await fetch('/api/graph');
+  const data = await res.json();
+  const elements = [];
+  data.nodes.forEach(n => {
+    elements.push({ data: { id: n.id, label: n.label } });
+  });
+  data.edges.forEach(e => {
+    elements.push({ data: { id: e.id, source: e.source, target: e.target, label: e.label } });
+  });
+  const cy = cytoscape({
+    container: document.getElementById('cy'),
+    elements,
+    style: [
+      { selector: 'node', style: { 'content': 'data(label)' } },
+      { selector: 'edge', style: { 'label': 'data(label)', 'curve-style': 'bezier', 'target-arrow-shape': 'triangle' } }
+    ],
+    layout: { name: 'cose' }
+  });
+}
+
+loadGraph();

--- a/server.js
+++ b/server.js
@@ -1,0 +1,59 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const data = JSON.parse(fs.readFileSync(path.join(__dirname, 'data/graph.json'), 'utf8'));
+
+function serveStatic(filePath, res) {
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200);
+    res.end(content);
+  });
+}
+
+function handleGraphQL(req, res) {
+  let body = '';
+  req.on('data', chunk => body += chunk);
+  req.on('end', () => {
+    try {
+      const { query } = JSON.parse(body);
+      let result = {};
+      if (/nodes\s*\{/.test(query)) result.nodes = data.nodes;
+      if (/edges\s*\{/.test(query)) result.edges = data.edges;
+      const nodeMatch = /node\(id:\s*"(\w+)"\)/.exec(query);
+      if (nodeMatch) {
+        result.node = data.nodes.find(n => n.id === nodeMatch[1]) || null;
+      }
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({ data: result }));
+    } catch (e) {
+      res.writeHead(400);
+      res.end('Invalid request');
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/api/graph') {
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify(data));
+  } else if (req.method === 'POST' && req.url === '/graphql') {
+    handleGraphQL(req, res);
+  } else if (req.method === 'GET' && (req.url === '/' || req.url === '/graph.html')) {
+    serveStatic(path.join(__dirname, 'public/graph.html'), res);
+  } else if (req.method === 'GET' && req.url === '/graph.js') {
+    serveStatic(path.join(__dirname, 'public/graph.js'), res);
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+server.listen(4000, () => {
+  console.log('Server running at http://localhost:4000');
+});


### PR DESCRIPTION
## Summary
- Add minimal Node-based graph server exposing REST and basic GraphQL endpoints
- Provide sample graph data and Cytoscape.js visualization page
- Document usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b4c9227f0832d855b15ff77d96649